### PR TITLE
fix: improve removal of oldest unpinned entry in StateManager SPDV-705

### DIFF
--- a/src/services/StateManager.ts
+++ b/src/services/StateManager.ts
@@ -100,22 +100,25 @@ export class StateManager {
   }
 
   private removeOldestUnpinnedEntry(state: StateEntry[]): StateEntry[] {
-    for (let i = 0; i < state.length; i++) {
-      const entry = state[i];
-      const streamId = `${entry.owner}/${entry.topic}`;
+    const unpinnedEntries = state.filter(entry => !entry.pinned);
 
-      if (!entry.pinned) {
-        this.logger.info(`Removing oldest unpinned entry: ${streamId}`);
-        return state.filter((_, index) => index !== i);
-      } else {
-        this.logger.info(`Skipping pinned stream: ${streamId}`);
-      }
+    if (unpinnedEntries.length === 0) {
+      const pinnedStreams = state.map(entry => `${entry.owner}/${entry.topic}`).join(', ');
+      throw new Error(
+        `Cannot add new entry: all ${state.length} existing entries are pinned (${pinnedStreams}). Please unpin some streams or increase the max state size.`,
+      );
     }
 
-    const pinnedStreams = state.map(entry => `${entry.owner}/${entry.topic}`).join(', ');
-    throw new Error(
-      `Cannot add new entry: all ${state.length} existing entries are pinned (${pinnedStreams}). Please unpin some streams or increase the max state size.`,
-    );
+    const oldestUnpinned = unpinnedEntries.reduce((oldest, current) => {
+      const oldestTime = oldest.updatedAt || oldest.createdAt || 0;
+      const currentTime = current.updatedAt || current.createdAt || 0;
+      return currentTime < oldestTime ? current : oldest;
+    });
+
+    const streamId = `${oldestUnpinned.owner}/${oldestUnpinned.topic}`;
+    this.logger.info(`Removing oldest unpinned entry: ${streamId}`);
+
+    return state.filter(entry => !(entry.owner === oldestUnpinned.owner && entry.topic === oldestUnpinned.topic));
   }
 
   private sortStateWithPinnedPriority(state: StateEntry[]): StateEntry[] {


### PR DESCRIPTION
# 🔖 Fix: Correct stream removal logic when state limit reached

_Fix incorrect stream removal behavior that was removing newest streams instead of oldest when the 5-stream limit was reached._

---

## 📝 Description

This PR fixes a critical bug in the StateManager where new streams were incorrectly replacing the most recent streams instead of the oldest ones when the maximum state size (5 streams) was reached. The issue was caused by a mismatch between the sorting order (newest first) and the removal logic (which assumed oldest entries were at the beginning of the array).

---

## 🔗 Related Issues
- https://solar-punk.atlassian.net/browse/SPDV-705
- Fixes stream ordering bug reported in Jira
- Related to StateManager stream limit functionality

---

## ✨ Changes Made

- **Fixed `removeOldestUnpinnedEntry` method** to find the actual oldest entry by timestamp instead of array position
- **Updated removal logic** to use timestamp comparison (`updatedAt` or `createdAt`) for accurate oldest entry identification
- **Improved error handling** to maintain existing behavior for pinned entries
- **Enhanced logging** to show the correct stream being removed

### Technical Details:
- Changed from position-based removal to timestamp-based removal
- Added proper unpinned entry filtering before timestamp comparison
- Maintained backward compatibility with existing pinned entry logic
- Used reduce function to find the entry with the smallest timestamp

---

## 🧪 How Has This Been Tested?


- [x] **Code Review**: Analyzed the sorting logic and removal method interaction
- [x] **Logic Verification**: Confirmed timestamp-based approach correctly identifies oldest entries
- [x] Manually tested with 5 streams scenario

### Test Scenarios to Verify:
1. Create 5 streams with different timestamps
2. Add a 6th stream and verify the oldest unpinned stream is removed
3. Verify pinned streams are preserved and never removed
4. Confirm new streams appear in the correct position (first/top)

---

## ✅ Checklist

- [x] My code follows the project's style guide
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass locally

---

## 🎯 Expected Behavior After Fix

**Before Fix:**
- New stream incorrectly replaced the most recent (last displayed) stream
- Stream order became incorrect with older streams remaining visible

**After Fix:**
- New stream correctly replaces the oldest unpinned stream
- New stream appears in first position (top/left)
- Other streams shift one position maintaining correct chronological order
- Pinned streams are always preserved regardless of age

---

## 📊 Impact

- **Bug Severity**: High (affects core user experience with stream browsing)
- **Risk Level**: Low (isolated change with clear logic improvement)
- **Backwards Compatibility**: Maintained (no API changes)
- **Performance**: Neutral (similar computational complexity)